### PR TITLE
Don't dispose the context in the controller

### DIFF
--- a/src/Experimental.AspNetCore.EF6/Controllers/ProductsController.cs
+++ b/src/Experimental.AspNetCore.EF6/Controllers/ProductsController.cs
@@ -74,10 +74,5 @@ namespace Experimental.AspNetCore.EF6.Controllers
             _dbContext.Entry(product).State = EntityState.Deleted;
             await _dbContext.SaveChangesAsync();
         }
-
-        protected override void Dispose(bool disposing)
-        {
-            _dbContext.Dispose();
-        }
     }
 }


### PR DESCRIPTION
- Since the context is injected as scoped, it'll go away when the request is over
- Generally we shouldn't dispose things we don't create directly.
